### PR TITLE
EES-5881 - added Azure Functions runtime support to the screener project and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM mcr.microsoft.com/azure-functions/base:4-slim
+# FROM mcr.microsoft.com/azure-functions/dotnet:4-appservice 
+FROM mcr.microsoft.com/azure-functions/dotnet:4
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
     dirmngr \
@@ -15,8 +19,5 @@ RUN R -e "pak::pkg_install('plumber')"
 RUN R -e "pak::pkg_install('dfe-analytical-services/eesyscreener')"
 RUN R -e "pak::pkg_install('readr')"
 
-COPY / /
-
-EXPOSE 8000
-
-ENTRYPOINT ["Rscript", "server.R"]
+WORKDIR /home/site/wwwroot
+COPY / /home/site/wwwroot

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Proof of concept for dockerising an R Plumber API for the [DfE's data screener](https://github.com/dfe-analytical-services/eesyscreener).
 
-## Running locally in VS Code
+## Running the R services directly
+
+### Running locally in VS Code
 
 1. Download R binary (https://www.stats.bris.ac.uk/R/)
 2. Download the [R Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r), you may be prompted to download the `languageservice` to use R code locally. Alternatively you can use an R-specific IDE such as [RStudio](https://posit.co/download/rstudio-desktop/)
@@ -10,16 +12,26 @@ Proof of concept for dockerising an R Plumber API for the [DfE's data screener](
 4. Open up Postman/PowerShell/curl etc. to hit the endpoints:
 
 ```
-GET localhost:8000/screen
-POST localhost:8000/screen
+GET localhost:8000/api/screen
+POST localhost:8000/api/screen
 ```
 > The GET endpoint is just to confirm the API is running.
 
 > For the POST endpoint, `dataFile` and `metaFile` arguments should be submitted with a `form-data` request body. Example files can be found in the "example-data" folder
 
-## Docker
+### Running locally from the CLI
 
-The API can also be run in a Docker container. Open up a terminal in the root of the project, and create an image using
+1. Ensure that Rscript is executable (check with `Rscript --version`).
+2. Run: `Rscript server.R`
+3. Call an endpoint at `http://localhost:8000/api/screen`.
+
+## Running the R services via the Azure Fucntions runtime
+
+### In Docker
+
+The API can also be run in a Docker container that is running the Azure Functions runtime.
+
+Open up a terminal in the root of the project, and create an image using
 
 ```
 docker build -t eesyscreener .
@@ -28,7 +40,30 @@ docker build -t eesyscreener .
 then run it using
 
 ```
-docker run --rm --name eesyscreener -p 8000:8000 eesyscreener
+docker run --rm --name eesyscreener -p 80:80 eesyscreener
+```
+
+and call the Azure Function endpoint at http://localhost/api/screen.
+
+### Locally
+
+The API can also be run directly from a local development environment, assuming that the required dependencies 
+have been installed. This includes:
+* (Azure Functions Core Tools)[https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=linux%2Cisolated-process%2Cnode-v4%2Cpython-v2%2Chttp-trigger%2Ccontainer-apps&pivots=programming-language-csharp#install-the-azure-functions-core-tools].
+* RScript, the eesyscreener R package and the various dependencies that eesyscreener will need to run.
+  For a full list of steps to install the dependencies required, refer to the commands executed in the
+  (Dockerfile)[./Dockerfile]/  
+
+After installing the above, the Azure Functions runtime can be started with:
+
+```
+func start
+```
+
+and the API can be called via the Azure Functions runtime by calling:
+
+```
+http://localhost:7071/api/screen
 ```
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dfe-ees-screener
 
-Proof of concept for dockerising an R Plumber API for the [DfE's data screener](https://github.com/dfe-analytical-services/eesyscreener).
+A containerised Azure Function App consisting of an R Plumber API for the [DfE's data screener](https://github.com/dfe-analytical-services/eesyscreener).
 
 ## Running the R services directly
 
@@ -49,10 +49,10 @@ and call the Azure Function endpoint at http://localhost/api/screen.
 
 The API can also be run directly from a local development environment, assuming that the required dependencies 
 have been installed. This includes:
-* (Azure Functions Core Tools)[https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=linux%2Cisolated-process%2Cnode-v4%2Cpython-v2%2Chttp-trigger%2Ccontainer-apps&pivots=programming-language-csharp#install-the-azure-functions-core-tools].
+* [Azure Functions Core Tools](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=linux%2Cisolated-process%2Cnode-v4%2Cpython-v2%2Chttp-trigger%2Ccontainer-apps&pivots=programming-language-csharp#install-the-azure-functions-core-tools).
 * RScript, the eesyscreener R package and the various dependencies that eesyscreener will need to run.
   For a full list of steps to install the dependencies required, refer to the commands executed in the
-  (Dockerfile)[./Dockerfile]/  
+  [Dockerfile](./Dockerfile).  
 
 After installing the above, the Azure Functions runtime can be started with:
 

--- a/host.json
+++ b/host.json
@@ -1,0 +1,23 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "customHandler": {
+    "description": {
+      "defaultExecutablePath": "Rscript",
+      "workingDirectory": "",
+      "arguments": ["server.R"]
+    },
+    "enableForwardingHttpRequest": true 
+  }
+}

--- a/local.settings.json
+++ b/local.settings.json
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "custom",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true"
+  }
+}

--- a/screen/function.json
+++ b/screen/function.json
@@ -1,0 +1,19 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/screen_controller.R
+++ b/screen_controller.R
@@ -1,6 +1,6 @@
 #* Test the service is running
 #* @serializer unboxedJSON
-#* @get /screen
+#* @get /api/screen
 test_get <- function() {
     list("Success")
 }
@@ -9,7 +9,7 @@ test_get <- function() {
 #* @parser multi
 #* @parser csv
 #* @serializer unboxedJSON
-#* @post /screen
+#* @post /api/screen
 screen <- function(req, res) {
     library(eesyscreener)
     library(vroom)

--- a/server.R
+++ b/server.R
@@ -1,3 +1,5 @@
+FORWARD_PORT <- Sys.getenv("FUNCTIONS_CUSTOMHANDLER_PORT", unset = 8000)
+
 library(plumber)
 pr("screen_controller.R") %>%
-    pr_run(host = "0.0.0.0", port = 8000)
+    pr_run(host = "0.0.0.0", port = FORWARD_PORT)


### PR DESCRIPTION
This PR:
- adds Azure Functions runtime support to the Screener app and its associated Dockerfile.  This allows the Azure Functions runtime to act as a bridge between the outside world and the Plumber web server running within the Docker container.
- This should also give us visibility of the registered Functions in the Function App resource within Azure Portal.
- This should also hopefully give us the ability to SSH onto the containers from Azure Portal, although it may be that the base image currently commented out in the Dockerfile might need to be instated for this to be supported.

At the moment, the /api/screen endpoint is set to `anonymous` access.  This should be correct if we're planning on using Easy Auth in front of this Function App project. 