### PR TITLE
Disabling content encoding on curl / Azure blob download

### DIFF
--- a/screen_controller.R
+++ b/screen_controller.R
@@ -57,8 +57,8 @@ screen <- function(req, res) {
     endpoint <- blob_endpoint(storage_account_url, key = storage_account_key)
     container <- blob_container(endpoint, blob_container_name)
 
-    storage_download(container, src = az_data_file_path, dest = temp_data_path, `Accept-Encoding` = gzip)
-    storage_download(container, src = az_meta_file_path, dest = temp_meta_path, `Accept-Encoding` = gzip)
+    storage_download(container, src = az_data_file_path, dest = temp_data_path)
+    storage_download(container, src = az_meta_file_path, dest = temp_meta_path)
   }
 
   result <- tryCatch({

--- a/screen_controller.R
+++ b/screen_controller.R
@@ -5,6 +5,10 @@ test_get <- function() {
   list("Success")
 }
 
+
+# Disable automatic content decoding for AzureStor
+options(azure_storage_disable_content_encoding = TRUE)
+
 #* Screen data set files located at the supplied blob storage paths using the eesyscreener package
 #* If the storage account environment variables are not set, local file paths will be assumed instead
 #* @parser json
@@ -53,8 +57,8 @@ screen <- function(req, res) {
     endpoint <- blob_endpoint(storage_account_url, key = storage_account_key)
     container <- blob_container(endpoint, blob_container_name)
 
-    storage_download(container, src = az_data_file_path, dest = temp_data_path)
-    storage_download(container, src = az_meta_file_path, dest = temp_meta_path)
+    storage_download(container, src = az_data_file_path, dest = temp_data_path, `Accept-Encoding` = gzip)
+    storage_download(container, src = az_meta_file_path, dest = temp_meta_path, `Accept-Encoding` = gzip)
   }
 
   result <- tryCatch({


### PR DESCRIPTION
## Overview of changes

The screener api is throwing an error when hit with a large file from Azure blob storage. We think it's related to the file encoding and compression:

```
<curl_error_bad_content_encoding in curl::curl_fetch_memory(url, handle = handle): Unrecognized or bad HTTP Content or Transfer-Encoding [data-storage]:
Error while processing content unencoding: incorrect header check>
```

After a bit of digging, I found the potential solution could just be an option to set in R:

`options(azure_storage_disable_content_encoding = TRUE)`

(thanks to Co-pilot)

Note that there's a further issue with gzip compressed files when read in by eesyscreener and I've got a PR for that here: 

https://github.com/dfe-analytical-services/eesyscreener/pull/14

We'll want to test both these changes in tandem to see if this fixes things.

## Why are these changes being made?

Screener app can't handle large files due to compression used on Azure.

## Checklist

<!-- Customise this checklist based on expectations for your repository -->

- [x] I have tested these changes locally using `shinytest2::test_app()`<!-- replace with your specific automated test command if different -->
- [x] I have updated the documentation
- [x] I have added or updated automated tests for these changes

## Reviewer instructions

<!-- Put any specific questions or instructions for reviewers in here -->