### PR TITLE
Move to Debian12 precompiled binar-EES

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true \
     R_VERSION=4.5.2
 
-# Install system dependencies and tools
+# Install system dependencies and tools - https://packagemanager.posit.co/client/#/repos/cran/setup
 RUN apt-get update && apt-get -y install --no-install-recommends \
     wget \
     gdebi-core \
@@ -28,13 +28,10 @@ RUN wget https://cdn.posit.co/r/debian-12/pkgs/r-${R_VERSION}_1_$(dpkg --print-a
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript
 
-# Install R packages using binaries
-RUN R -e "install.packages(c('plumber', 'desc', 'pak'), repos = 'https://packagemanager.posit.co/cran/__linux__/bookworm/latest'); \
-           desc_local <- tempfile(fileext = '.DESCRIPTION'); \
-           download.file('https://raw.githubusercontent.com/dfe-analytical-services/eesyscreener/main/DESCRIPTION', desc_local, quiet = TRUE); \
-           deps <- desc::desc_get_deps(file = desc_local); \
-           install.packages(deps[deps[['type']] == 'Imports', 'package'], repos = 'https://packagemanager.posit.co/cran/__linux__/bookworm/latest'); \
-           pak::pak('dfe-analytical-services/eesyscreener@v0.1.5');"
+# Install R packages using pre-complied binaries for Debian 12 (Bookworm)
+RUN R -e "options(repos = c(CRAN = 'https://packagemanager.posit.co/cran/__linux__/bookworm/latest')); \
+           install.packages('pak'); \
+           pak::pak(c('plumber@1.3.0', 'dfe-analytical-services/eesyscreener@v0.1.5'));"
 
 WORKDIR /home/site/wwwroot
 COPY / /home/site/wwwroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,40 @@
-FROM mcr.microsoft.com/azure-functions/dotnet:4
+FROM mcr.microsoft.com/azure-functions/dotnet:4-dotnet8.0
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
-    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true \
+    R_VERSION=4.5.2
 
+# Install system dependencies and tools
 RUN apt-get update && apt-get -y install --no-install-recommends \
+    wget \
+    gdebi-core \
+    ca-certificates \
     dirmngr \
     gpg \
-    gpg-agent
-
-RUN echo "deb http://cloud.r-project.org/bin/linux/debian bullseye-cran40/" >> /etc/apt/sources.list
-RUN gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7
-RUN gpg -a --export 95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7 | apt-key add -
-
-RUN apt-get update && apt-get -y install --no-install-recommends \
+    gpg-agent \
     g++ \
     cmake \
     build-essential \
-    r-base \
-    r-base-dev \
     libcurl4-openssl-dev \
     libssl-dev \
+    libssh2-1-dev \
+    xz-utils \
     curl
 
-RUN R -e "install.packages('pak');"
-RUN R -e "pak::pak('plumber@1.3.0');"
-RUN R -e "pak::pak('dfe-analytical-services/eesyscreener@v0.1.5');"
+# Install R from Posit's official binary for Debian 12 (Bookworm)
+RUN wget https://cdn.posit.co/r/debian-12/pkgs/r-${R_VERSION}_1_$(dpkg --print-architecture).deb && \
+    gdebi -n r-${R_VERSION}_1_$(dpkg --print-architecture).deb && \
+    rm r-${R_VERSION}_1_$(dpkg --print-architecture).deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript
+
+# Install R packages using binaries
+RUN R -e "install.packages(c('plumber', 'desc', 'pak'), repos = 'https://packagemanager.posit.co/cran/__linux__/bookworm/latest'); \
+           desc_local <- tempfile(fileext = '.DESCRIPTION'); \
+           download.file('https://raw.githubusercontent.com/dfe-analytical-services/eesyscreener/main/DESCRIPTION', desc_local, quiet = TRUE); \
+           deps <- desc::desc_get_deps(file = desc_local); \
+           install.packages(deps[deps[['type']] == 'Imports', 'package'], repos = 'https://packagemanager.posit.co/cran/__linux__/bookworm/latest'); \
+           pak::pak('dfe-analytical-services/eesyscreener@v0.1.5');"
 
 WORKDIR /home/site/wwwroot
 COPY / /home/site/wwwroot


### PR DESCRIPTION
## Overview of changes

On Friday I was talking with @rmbielby about the approaches we'd tried before and why I couldn't get the precompiled binaries working, when, I noticed that the base image had been updated the day before (22nd Jan 26) and was now running Debian 12 - https://hub.docker.com/r/microsoft/azure-functions-dotnet.

This then meant we could line up pre-compiled binaries for R, and individual R packages, with the image OS, as they only start from Debian 12 onwards.

I also reviewed the list of suggested system requirements from - https://packagemanager.posit.co/client/#/repos/cran/setup - and added a couple for the packages I know are in eesyscreener currently but weren't already in our Dockerfile (`libssh2-1-dev` + `xz-utils`).

## Why are these changes being made?

Before it used to take me at least an hour, sometimes two hours, to build the image, almost entirely due to the R packages themselves building from source. Now, with the juicy juicy precompiled binar-EES it installs packages in less than 50s...

<img width="1240" height="377" alt="image" src="https://github.com/user-attachments/assets/5d7df8bd-1adf-4375-9c48-456316d1ff62" />

## Checklist

- [ ] I have tested these changes locally using
- [ ] I have updated the documentation
- [ ] I have added or updated automated tests for these changes

## Reviewer instructions

1. I have removed the potentially secure approach used before with a key in changing how R is installed here, I don't know much about that - so worth checking over the `wget` line in particular in case there are any improvements to make
2. I haven't tested if the updated docker base image will work with Azure Functions - I hope it would but will need a dev to take the lead on testing during deployment