### PR TITLE
EES-7000 - added /progress endpoint to allow other services to check screening progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See [Request format](#request-format) for details on how to construct API reques
 GET localhost:8000/api/healthcheck
 POST localhost:8000/api/screen
 POST localhost:8000/function_start_screening
+GET localhost:8000/api/progress?dataSetId=<data set id>
 ```
 
 ### Running locally from the CLI

--- a/function_check_progress/function.json
+++ b/function_check_progress/function.json
@@ -1,0 +1,19 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get"
+      ],
+      "route": "progress"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/routes.R
+++ b/routes.R
@@ -27,3 +27,11 @@ start_screening_route <- function(req, res) {
   source(here::here("src/function_handlers/handle_start_screening.R"))
   handle_start_screening(req, res)
 }
+
+#* @parser json
+#* @serializer unboxedJSON
+#* @get /api/progress
+screen_route <- function(req, res) {
+  source(here::here("src/function_handlers/handle_check_progress.R"))
+  handle_check_progress(req, res)
+}

--- a/src/function_handlers/handle_check_progress.R
+++ b/src/function_handlers/handle_check_progress.R
@@ -1,0 +1,29 @@
+#* Check the screening progress for a particular data set.
+handle_check_progress <- function(req, res) {
+
+  source(here::here("src/services/check_progress.R"))
+  
+  data_set_id <- req$args$dataSetId
+
+  if (is.null(data_set_id)) {
+    res$status <- 400
+    return(list(
+      message = "Query parameter dataSetId must be specified."
+    ))
+  }
+
+  progress = check_progress(data_set_id)
+
+  if (is.null(progress)) {
+    res$status <- 404
+    return(list(
+      message = paste0("A progress file for dataSetId \"", data_set_id, "\" was not found.")
+    ))
+  }
+
+  res$status <- 200
+  res$body <- list(
+    percentComplete = progress$progress,
+    stage = progress$status[1]
+  )
+}

--- a/src/services/check_progress.R
+++ b/src/services/check_progress.R
@@ -1,0 +1,23 @@
+library(jsonlite)
+
+check_progress <- function(data_set_id) {
+  
+  log_dir <- Sys.getenv("LOG_DIR")
+  progress_filename <- paste0(log_dir, "/", "eesyscreener_log_", data_set_id, ".json")
+  
+  message(paste0("Looking for progress file ", progress_filename))
+
+  if (!file.exists(progress_filename)) {
+    message(paste0("Unable to find progress file ", progress_filename))
+    return(NULL)
+  }
+
+  message(paste0("Found progress file ", progress_filename))
+    
+  file_contents <- fromJSON(progress_filename)
+
+  list(
+    progress = file_contents$progress,
+    status = file_contents$status
+  )
+}

--- a/tests/testthat/setup-api.R
+++ b/tests/testthat/setup-api.R
@@ -5,6 +5,8 @@ source("../../create_server.R")
 
 seconds_to_wait_for_server_start = 30
 
+log_dir = tempdir()
+
 api_host <- function() "127.0.0.1"
 api_port <- function() 13001
 api_url <- function(host = api_host(), port = api_port()) {
@@ -20,14 +22,15 @@ api_start <- function(host = api_host(), port = api_port(), server = create_serv
   mirai::daemons(1L, dispatcher = FALSE, autoexit = tools::SIGINT, output = TRUE)
   m <- mirai::mirai(
     {
-      withr::local_envvar(LOG_DIR = "/tmp")
+      withr::local_envvar(LOG_DIR = log_dir)
 
       server |>
         plumber::pr_run(host = host, port = port)
     },
     host = host,
     port = port,
-    server = server
+    server = server,
+    log_dir = log_dir
   )
 
   withr::defer(envir = testthat::teardown_env(), {

--- a/tests/testthat/test-api-check-progress.R
+++ b/tests/testthat/test-api-check-progress.R
@@ -1,0 +1,63 @@
+library(jsonlite)
+
+source("utils/progress_file_test_utils.R")
+
+testthat::test_that("GET to the progress function without a dataSetId returns a 400", {
+  request <- api_url(api_host(), api_port()) |>
+    httr2::request() |>
+    httr2::req_error(is_error = function(resp) FALSE) |>
+    httr2::req_url_path("api/progress") |>
+    httr2::req_method("GET")
+
+  resp <- httr2::req_perform(request)
+
+  expect_equal(httr2::resp_status(resp), 400)
+
+  result <- httr2::resp_body_json(resp)
+
+  expect_equal(result$message, "Query parameter dataSetId must be specified.")
+})
+
+
+testthat::test_that("GET to the progress function with a dataSetId for a non-existent progress file returns a 404", {
+  request <- api_url(api_host(), api_port()) |>
+    httr2::request() |>
+    httr2::req_error(is_error = function(resp) FALSE) |>
+    httr2::req_url_path("api/progress") |>
+    httr2::req_url_query(dataSetId = "not_found") |>
+    httr2::req_method("GET")
+
+  resp <- httr2::req_perform(request)
+
+  expect_equal(httr2::resp_status(resp), 404)
+
+  result <- httr2::resp_body_json(resp)
+
+  expect_equal(result$message, "A progress file for dataSetId \"not_found\" was not found.")
+})
+
+
+testthat::test_that("GET to the progress function with a dataSetId for an existing progress file returns the current progress", {
+  
+  data_set_id = "existing"
+  percentage_complete = 90.12
+  stage = "started"
+
+  # Create a temporary existing progress file.
+  create_progress_file(data_set_id, percentage_complete, stage)
+
+  request <- api_url(api_host(), api_port()) |>
+    httr2::request() |>
+    httr2::req_url_path("api/progress") |>
+    httr2::req_url_query(dataSetId = data_set_id) |>
+    httr2::req_method("GET")
+
+  resp <- httr2::req_perform(request)
+
+  expect_equal(httr2::resp_status(resp), 200)
+
+  result <- httr2::resp_body_json(resp)
+
+  expect_equal(result$percentComplete, percentage_complete)
+  expect_equal(result$stage, stage)
+})

--- a/tests/testthat/utils/progress_file_test_utils.R
+++ b/tests/testthat/utils/progress_file_test_utils.R
@@ -1,0 +1,19 @@
+#* Create a progress JSON file to represent the current screening progress for a particular data set.
+create_progress_file <- function(data_set_id, percentage_complete, stage) {
+  
+  file_content <- list(
+    progress = percentage_complete,
+    status = stage,
+    results = list(
+      list(
+        check = "meta_ind_unit",
+        result = "PASS",
+        message = "No filters have an indicator_unit value.",
+        guidance_url = "NA",
+        stage = "Check meta"
+      )
+    )
+  )
+
+  write_json(file_content, paste0(tempdir(), "/eesyscreener_log_", data_set_id, ".json"))
+}


### PR DESCRIPTION
This PR:
- adds a new `GET /api/progress?dataSetId=<dataSetId>` endpoint to allow external services to check on the screening progress for a given `dataSetId`.  The `dataSetId` is the same as is provided when originally calling the `start_screening` queue-triggered function from EES-6999.
- removes the hard-coded `/tmp` LOG_DIR value when running unit tests, using OS-agnostic `tempdir()` function instead.

The new endpoint looks for a file called `<log dir>/eesyscreener_log_<dataSetId>.json`.  If it can't find one it'll return a 404, otherwise it'll return details as held in the file.

This file is emitted from `eesyscreener` itself when the queue-triggered `start screening` function is called and screening progresses.  