### PR TITLE
EES-7176 - limiting the maximum number of concurrent "start-screening" queue messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,3 +39,17 @@ COPY / /home/site/wwwroot
 RUN R -e "options(repos = c(CRAN = 'https://packagemanager.posit.co/cran/__linux__/bookworm/latest')); \
           install.packages('pak'); \
           pak::pkg_install(c('dfe-analytical-services/eesyscreener@v0.3.1', 'deps::.'));"
+
+# Limit the number of concurrent background screening jobs to 1 less than the number of concurrent R
+# workers. This allows 1 worker to always be free to process progress update requests whilst the
+# other workers are busy screening in the background.
+#
+# "newBatchThreshold" in host.json is set to 0 so that a new batch of background screening requests
+# will only be fetched when all background screening processes have completed, thus ensuring we only
+# run the desired maximum number of background screening processes at a time.
+RUN \
+  if [ "$CONCURRENT_R_WORKERS" = "0" ] || [ "$CONCURRENT_R_WORKERS" = "1" ]; then \
+    echo "export AzureFunctionsJobHost__extensions__queues__batchSize=1" >> /etc/profile; \
+  else \
+    echo "export AzureFunctionsJobHost__extensions__queues__batchSize=$((CONCURRENT_R_WORKERS - 1))" >> /etc/profile; \
+  fi

--- a/host.json
+++ b/host.json
@@ -22,7 +22,8 @@
   },
   "extensions": {
     "queues": {
-      "maxPollingInterval": "00:00:02"
+      "maxPollingInterval": "00:00:02",
+      "newBatchThreshold": 0
     }
   }
 }


### PR DESCRIPTION
This PR:
- configures the Screener API function app to impose a maximum number of concurrent background screening attempts, so as to allow 1 R worker to be free to process progress updates.

This works by limiting the max number of "start screening" messages that will be fetched at any given time, by setting "batchSize" to be 1 less than the number of R workers, and "newBatchThreshold" set to 0 so that a new batch is only fetched when all ongoing background screening processes have completed.

So if `CONCURRENT_R_WORKERS` is set to 4, `batchSize` will be 3, allowing a maximum of 3 "start screening" messages to be picked up and processed, leaving 1 worker free to handle other requests.  If 3 messages are picked up, another batch will not to picked up until all 3 current processes have completed, thus further ensuring that we still have a free worker thread at any given time.