### PR TITLE
Updating duckdb install in dockerfile to get binary for install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,18 @@ COPY / /home/site/wwwroot
 # Install R packages using pre-complied binaries for Debian 12 (Bookworm)
 RUN R -e "options(repos = c(CRAN = 'https://packagemanager.posit.co/cran/__linux__/bookworm/latest')); \
           install.packages('pak'); \
-          pak::pkg_install(c('dfe-analytical-services/eesyscreener@v0.3.2', 'deps::.'));"
+          install.packages( \
+            'duckdb', \
+            repos = sprintf( \
+                'https://p3m.dev/cran/latest/bin/linux/manylinux_2_28-%s/%s', \
+                R.version['arch'], \
+                substr(getRversion(), 1, 3) \
+            ) \
+          ); \
+          pak::pkg_install(c('dfe-analytical-services/eesyscreener@v0.3.2', 'deps::.'), upgrade = FALSE);"
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-
 # Call entrypoint script to dynamically set the "batchSize" queue property
 # as an environment variable, based upon the value of "CONCURRENT_R_WORKERS".
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -111,6 +111,21 @@ pak::pak(
 )
 ```
 
+In Linux, the recommended duckdb install is from binary with the following:
+
+```
+install.packages( 
+  'duckdb', 
+  repos = sprintf( 
+    'https://p3m.dev/cran/latest/bin/linux/manylinux_2_28-%s/%s', 
+    R.version['arch'], 
+    substr(getRversion(), 1, 3) 
+  ) 
+)
+```
+
+Installing from source currently takes 50-60 mins, so not advised!
+
 #### Alternative package management
 
 Note on pkg.lock file. This was added as part of development, but is not currently used in workflows.


### PR DESCRIPTION
## Overview of changes

duckdb is taking 50-60mins to build from source. I've pulled the guidance on getting binary duckdb for Linux installed from https://r.duckdb.org/

## Reviewer instructions

I can't actually build Docker containers on my DfE laptop, so coding this a bit blind and can't test myself. Would be good to know if this a) works and b) solves it in a way that works for Dev's building locally.